### PR TITLE
Multi-server instance filtering and no remove on startup

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -80,7 +80,7 @@ Meteor.methods({
         _id: this.connection.id
       };
       
-      Presences.upsert(filter, update);
+      Presences.upsert(filter, update, function(err, res) { /* do nothing */ });
     }
   },
   presenceTick: function() {


### PR DESCRIPTION
enabled two methods depending on environment settings inside `process.env.*`.

```
#export PRESENCE_DONT_CLEAR=true
export PRESENCE_INSTANCE='testing-server-001'
```
- `PRESENCE_DONT_CLEAR` - will just not clear the `Presence` collection, need to manually process it in the code.
- `PRESENCE_INSTANCE` - setting this will allocate a server instance identifier to each `Presence` document connected to that server. On restart it will generate a new `serverInstanceId` and remove any other records from old instances on the specified server only.
- If no environment variables specified, it will run as it currently does.

```
{
  instance: {
    name: "testing-server-001",
    id: "33erfljrkrj3hdkjhd3"
  }
}
```
