### PR TITLE
Migrating from new Meteor.Collection to new Mongo.Collection

### DIFF
--- a/lib/common.js
+++ b/lib/common.js
@@ -1,4 +1,4 @@
-Presences = new Meteor.Collection('presences');
+Presences = new Mongo.Collection('presences');
 // For backwards compatibilty
 Meteor.presences = Presences;
 


### PR DESCRIPTION
Small update... Meteor.Collection was renamed Mongo.Collection in Meteor 0.9.1